### PR TITLE
Bump alexa-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "josh skeen",
   "license": "ISC",
   "dependencies": {
-    "alexa-app": "^2.3.2",
+    "alexa-app": "^3.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "lodash": "^4.3.0",


### PR DESCRIPTION
The tutorial doesn't specify a version of the alexa-app-dev server to
use. Using the latest alexa-app-dev with version 2 of alexa-app will
result in an express error